### PR TITLE
Add Neovim plugin configurations for dashboard, dressing, flash, harpoon, noice, notify, surround, todo-comments, trouble, undotree, and zen-mode

### DIFF
--- a/lua/shreyuu/plugin/dashboard.lua
+++ b/lua/shreyuu/plugin/dashboard.lua
@@ -1,0 +1,22 @@
+return {
+    "nvimdev/dashboard-nvim",
+    event = "VimEnter",
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    config = function()
+      require("dashboard").setup({
+        theme = "doom",
+        config = {
+          header = {
+            "⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿",
+            "          Welcome back, Shreyuu ⚡",
+            "⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿",
+          },
+          center = {
+            { icon = " ", desc = " Find File", action = "Telescope find_files" },
+            { icon = " ", desc = " Quit Neovim", action = "qa" },
+          },
+          footer = { "🚀 Build something awesome today!" },
+        },
+      })
+    end,
+  }

--- a/lua/shreyuu/plugin/dressing.lua
+++ b/lua/shreyuu/plugin/dressing.lua
@@ -1,0 +1,7 @@
+return {
+    "stevearc/dressing.nvim",
+    event = "VeryLazy",
+    config = function()
+      require("dressing").setup()
+    end,
+  }

--- a/lua/shreyuu/plugin/flash.lua
+++ b/lua/shreyuu/plugin/flash.lua
@@ -1,0 +1,7 @@
+return {
+    "folke/flash.nvim",
+    event = "VeryLazy",
+    config = function()
+      require("flash").setup()
+    end,
+  }

--- a/lua/shreyuu/plugin/harpoon.lua
+++ b/lua/shreyuu/plugin/harpoon.lua
@@ -1,0 +1,10 @@
+return {
+    "ThePrimeagen/harpoon",
+    branch = "harpoon2",
+    dependencies = { "nvim-lua/plenary.nvim" },
+    event = "VeryLazy",
+    config = function()
+      local harpoon = require("harpoon")
+      harpoon:setup()
+    end,
+  }

--- a/lua/shreyuu/plugin/noice.lua
+++ b/lua/shreyuu/plugin/noice.lua
@@ -1,0 +1,23 @@
+return {
+    "folke/noice.nvim",
+    event = "VeryLazy",
+    dependencies = {
+      "MunifTanjim/nui.nvim",
+      "rcarriga/nvim-notify",
+    },
+    config = function()
+      require("noice").setup({
+        lsp = {
+          override = {
+            ["vim.lsp.util.convert_input_to_markdown_lines"] = true,
+            ["vim.lsp.util.stylize_markdown"] = true,
+            ["cmp.entry.get_documentation"] = true,
+          },
+        },
+        presets = {
+          command_palette = true,
+          long_message_to_split = true,
+        },
+      })
+    end,
+  }

--- a/lua/shreyuu/plugin/notify.lua
+++ b/lua/shreyuu/plugin/notify.lua
@@ -1,0 +1,7 @@
+return {
+    "rcarriga/nvim-notify",
+    event = "VeryLazy",
+    config = function()
+      vim.notify = require("notify")
+    end,
+  }

--- a/lua/shreyuu/plugin/surround.lua
+++ b/lua/shreyuu/plugin/surround.lua
@@ -1,0 +1,4 @@
+return {
+    "tpope/vim-surround",
+    event = "VeryLazy",
+  }

--- a/lua/shreyuu/plugin/todo-comments.lua
+++ b/lua/shreyuu/plugin/todo-comments.lua
@@ -1,0 +1,8 @@
+return {
+    "folke/todo-comments.nvim",
+    event = "VeryLazy",
+    dependencies = { "nvim-lua/plenary.nvim" },
+    config = function()
+      require("todo-comments").setup()
+    end,
+  }

--- a/lua/shreyuu/plugin/trouble.lua
+++ b/lua/shreyuu/plugin/trouble.lua
@@ -1,0 +1,8 @@
+return {
+    "folke/trouble.nvim",
+    cmd = "TroubleToggle",
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    config = function()
+      require("trouble").setup()
+    end,
+  }

--- a/lua/shreyuu/plugin/undotree.lua
+++ b/lua/shreyuu/plugin/undotree.lua
@@ -1,0 +1,4 @@
+return {
+    "mbbill/undotree",
+    cmd = "UndotreeToggle",
+  }

--- a/lua/shreyuu/plugin/zen-mode.lua
+++ b/lua/shreyuu/plugin/zen-mode.lua
@@ -1,0 +1,7 @@
+return {
+    "folke/zen-mode.nvim",
+    cmd = "ZenMode",
+    config = function()
+      require("zen-mode").setup()
+    end,
+  }


### PR DESCRIPTION
This pull request adds several new plugins to the Neovim configuration, each with its own setup and event triggers. The most important changes include the addition of a dashboard plugin, a notification plugin, and various utility plugins.

### Dashboard and Notification Plugins:

* Added the `nvimdev/dashboard-nvim` plugin to provide a customizable dashboard on VimEnter event. This includes a themed header, center actions, and a footer message. (`lua/shreyuu/plugin/dashboard.lua`)
* Added the `rcarriga/nvim-notify` plugin to handle notifications, configured to be lazy-loaded. (`lua/shreyuu/plugin/notify.lua`)

### Utility Plugins:

* Added the `folke/noice.nvim` plugin to enhance the Neovim UI, with dependencies and specific LSP configurations. (`lua/shreyuu/plugin/noice.lua`)
* Added the `ThePrimeagen/harpoon` plugin for quick file navigation, configured to be lazy-loaded. (`lua/shreyuu/plugin/harpoon.lua`)
* Added the `folke/trouble.nvim` plugin to provide a diagnostics list, configured to be triggered by the `TroubleToggle` command. (`lua/shreyuu/plugin/trouble.lua`)