### PR TITLE
Refactor LSP plugin configuration for improved readability and structure

### DIFF
--- a/lua/shreyuu/init.lua
+++ b/lua/shreyuu/init.lua
@@ -1,10 +1,5 @@
 require("shreyuu.set")
 require("shreyuu.remap")
-require("shreyuu.lazy_init")
 
 -- Plugin configs
-require("shreyuu.plugin.lsp")
-require("shreyuu.plugin.cmp")
-require("shreyuu.plugin.treesitter")
-require("shreyuu.plugin.autopairs")
-require("shreyuu.plugin.theme")
+require("shreyuu.lazy_init")

--- a/lua/shreyuu/plugin/lsp.lua
+++ b/lua/shreyuu/plugin/lsp.lua
@@ -1,25 +1,24 @@
 return {
-    "neovim/nvim-lspconfig",
-    event = { "BufReadPre", "BufNewFile" },
-    dependencies = {
-      "williamboman/mason.nvim",
-      "williamboman/mason-lspconfig.nvim",
-    },
-    config = function()
-      require("mason").setup()
-      require("mason-lspconfig").setup({
-        ensure_installed = { "lua_ls", "pyright", "tsserver", "html", "cssls" },
+  "neovim/nvim-lspconfig",
+  event = { "BufReadPre", "BufNewFile" },
+  dependencies = {
+    "williamboman/mason.nvim",
+    "williamboman/mason-lspconfig.nvim",
+  },
+  config = function()
+    require("mason").setup()
+    require("mason-lspconfig").setup({
+      ensure_installed = { "lua_ls", "pyright", "ts_ls", "html", "cssls" },
+    })
+
+    local lspconfig = require("lspconfig")
+    local capabilities = require("cmp_nvim_lsp").default_capabilities()
+
+    local servers = { "lua_ls", "pyright", "ts_ls", "html", "cssls" }
+    for _, server in ipairs(servers) do
+      lspconfig[server].setup({
+        capabilities = capabilities,
       })
-  
-      local lspconfig = require("lspconfig")
-      local capabilities = require("cmp_nvim_lsp").default_capabilities()
-  
-      local servers = { "lua_ls", "pyright", "tsserver", "html", "cssls" }
-      for _, server in ipairs(servers) do
-        lspconfig[server].setup({
-          capabilities = capabilities,
-        })
-      end
-    end,
-  }
-  
+    end
+  end,
+}


### PR DESCRIPTION
This pull request includes changes to the Lua configuration files for the Shreyuu project. The main focus is on reordering plugin initialization and updating the server names for the LSP configuration.

Reorganization of plugin initialization:

* [`lua/shreyuu/init.lua`](diffhunk://#diff-67b97f625b5bd98f41f7b01ae18db1ea9be4e995deda94928e5728f6f1eba158L3-R5): Moved the `require("shreyuu.lazy_init")` line to be after the other `require` statements.

Updates to LSP configuration:

* [`lua/shreyuu/plugin/lsp.lua`](diffhunk://#diff-ae4319da6400a6672c562b807ee190b5fbd140cafb0ab21918ca9bf72e97d956L11-L25): Changed the server name from `tsserver` to `ts_ls` in both the `ensure_installed` and `servers` lists.